### PR TITLE
Adjust admin settings layout

### DIFF
--- a/models/knowledgeDocument.js
+++ b/models/knowledgeDocument.js
@@ -11,6 +11,7 @@ const KnowledgeDocumentSchema = new mongoose.Schema({
   spreadsheetId: { type: String, required: true },
   title: String,
   columns: [ColumnSchema],
+  rows: { type: [[String]], default: [] },
   createdAt: { type: Date, default: Date.now },
   updatedAt: { type: Date, default: Date.now }
 });

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -506,6 +506,7 @@
                         </div>
                         <div class="card-body">
                             <form id="settings-form">
+                                <h5 class="mt-0">Notifications</h5>
                                 <div class="mb-3">
                                     <label for="notification-setting" class="form-label">Notifications</label>
                                     <select class="form-select" id="notification-setting">
@@ -523,7 +524,12 @@
                                     <input type="number" class="form-control" id="auto-refresh" min="5" value="30">
                                 </div>
 
-                                <h5 class="mt-4">PDF Column Configuration</h5>
+                                <h5 class="mt-4">PDF Configuration</h5>
+                                <div class="mb-3 form-check">
+                                    <input type="checkbox" class="form-check-input" id="enable-pdf">
+                                    <label class="form-check-label" for="enable-pdf">Allow chatbot to generate PDFs</label>
+                                </div>
+                                <h6 class="mt-3">PDF Column Configuration</h6>
                                 <div class="mb-3">
                                     <label class="form-label">Apartment Information Columns</label>
                                     <div id="column-config-container" class="list-group">
@@ -591,10 +597,28 @@
                                     </div>
                                 </div>
 
-                                <h5 class="mt-4">Google Knowledge</h5>
+                                <h5 class="mt-4">Knowledge Configuration</h5>
                                 <div class="mb-3">
                                     <button type="button" class="btn btn-secondary" id="connect-google">Connect Google Account</button>
                                 </div>
+                                <div class="row g-2 mb-3">
+                                    <div class="col-auto">
+                                        <input type="text" class="form-control" id="drive-query" placeholder="Search Drive">
+                                    </div>
+                                    <div class="col-auto">
+                                        <button type="button" class="btn btn-outline-secondary" id="search-drive">Search</button>
+                                    </div>
+                                </div>
+                                <ul class="list-group mb-3" id="drive-results"></ul>
+                                <div class="d-flex mb-2 align-items-center">
+                                    <h6 class="me-auto mb-0">Saved Spreadsheets</h6>
+                                    <div class="input-group input-group-sm w-auto me-2">
+                                        <input type="text" class="form-control" id="knowledge-query" placeholder="Search Saved">
+                                        <button class="btn btn-outline-secondary" type="button" id="search-knowledge">Search</button>
+                                    </div>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="refresh-knowledge">Refresh</button>
+                                </div>
+                                <ul class="list-group mb-3" id="knowledge-list"></ul>
                                 <div class="mb-3">
                                     <label for="spreadsheet-id" class="form-label">Spreadsheet ID</label>
                                     <input type="text" class="form-control" id="spreadsheet-id">
@@ -606,7 +630,6 @@
                                 <button type="button" class="btn btn-secondary mb-3" id="load-spreadsheet">Load Spreadsheet</button>
                                 <table class="table" id="spreadsheet-table"></table>
 
-                                <button type="submit" class="btn btn-primary">Save Settings</button>
                             </form>
                         </div>
                     </div>

--- a/routes/google.js
+++ b/routes/google.js
@@ -4,6 +4,7 @@ const GoogleAuthService = require('../services/googleAuth');
 const GoogleSheetsService = require('../services/googleSheets');
 const UserGoogleDrive = require('../services/userGoogleDrive');
 const KnowledgeService = require('../services/knowledge');
+const { logger } = require('../services/logging');
 
 const router = express.Router();
 const authService = new GoogleAuthService();
@@ -17,6 +18,7 @@ router.get('/auth/url', auth, (req, res) => {
     const url = authService.generateAuthUrl(req.user.id.toString());
     res.json({ url });
   } catch (err) {
+    logger.error('Failed to generate auth url', { error: err });
     res.status(500).json({ error: 'Failed to generate auth url' });
   }
 });
@@ -31,6 +33,7 @@ router.get('/oauth2callback', async (req, res) => {
     await authService.handleOAuthCallback(state, code);
     res.send('Google authorization successful. You can close this window.');
   } catch (err) {
+    logger.error('Failed OAuth callback', { error: err });
     res.status(500).send('Failed to authorize with Google');
   }
 });
@@ -41,6 +44,7 @@ router.post('/token', auth, async (req, res) => {
     await authService.saveTokens(req.user.id, req.body);
     res.json({ success: true });
   } catch (err) {
+    logger.error('Failed to save Google tokens', { error: err });
     res.status(500).json({ error: 'Failed to save token' });
   }
 });
@@ -51,6 +55,7 @@ router.get('/status', auth, async (req, res) => {
     const authorized = await authService.hasTokens(req.user.id);
     res.json({ authorized });
   } catch (err) {
+    logger.error('Failed to check Google auth status', { error: err });
     res.status(500).json({ error: 'Failed to check status' });
   }
 });
@@ -61,6 +66,7 @@ router.get('/drive/search', auth, async (req, res) => {
     const files = await driveService.searchSpreadsheets(req.user.id, req.query.q || '');
     res.json({ files });
   } catch (err) {
+    logger.error('Failed to search Google Drive', { error: err });
     res.status(500).json({ error: 'Failed to search drive' });
   }
 });
@@ -72,6 +78,7 @@ router.post('/knowledge/import', auth, async (req, res) => {
     const doc = await knowledgeService.importSpreadsheet(req.user.id, spreadsheetId, exclude || []);
     res.json({ doc });
   } catch (err) {
+    logger.error('Failed to import spreadsheet', { error: err });
     res.status(500).json({ error: 'Failed to import spreadsheet' });
   }
 });
@@ -82,6 +89,7 @@ router.get('/knowledge', auth, async (req, res) => {
     const docs = await knowledgeService.list(req.user.id, req.query.q || '');
     res.json({ docs });
   } catch (err) {
+    logger.error('Failed to list knowledge documents', { error: err });
     res.status(500).json({ error: 'Failed to list documents' });
   }
 });
@@ -93,6 +101,7 @@ router.get('/knowledge/:id', auth, async (req, res) => {
     if (!doc) return res.status(404).json({ error: 'Not found' });
     res.json({ doc });
   } catch (err) {
+    logger.error('Failed to get knowledge document', { error: err });
     res.status(500).json({ error: 'Failed to get document' });
   }
 });
@@ -103,6 +112,7 @@ router.post('/knowledge/:id/refresh', auth, async (req, res) => {
     const doc = await knowledgeService.refresh(req.user.id, req.params.id);
     res.json({ doc });
   } catch (err) {
+    logger.error('Failed to refresh knowledge document', { error: err });
     res.status(500).json({ error: 'Failed to refresh document' });
   }
 });
@@ -114,6 +124,7 @@ router.post('/knowledge/:id/columns', auth, async (req, res) => {
     const doc = await knowledgeService.updateColumns(req.user.id, req.params.id, excluded || []);
     res.json({ doc });
   } catch (err) {
+    logger.error('Failed to update excluded columns', { error: err });
     res.status(500).json({ error: 'Failed to update columns' });
   }
 });
@@ -130,6 +141,7 @@ router.get('/sheets/:spreadsheetId', auth, operator, async (req, res) => {
     );
     res.json(data);
   } catch (err) {
+    logger.error('Failed to fetch spreadsheet', { error: err });
     res.status(500).json({ error: 'Failed to fetch sheet' });
   }
 });

--- a/routes/google.js
+++ b/routes/google.js
@@ -62,11 +62,13 @@ router.get('/status', auth, async (req, res) => {
 
 // Search user drive for spreadsheets
 router.get('/drive/search', auth, async (req, res) => {
+  const query = req.query.q || '';
   try {
-    const files = await driveService.searchSpreadsheets(req.user.id, req.query.q || '');
+    logger.info('Drive search requested', { userId: req.user.id, query });
+    const files = await driveService.searchSpreadsheets(req.user.id, query);
     res.json({ files });
   } catch (err) {
-    logger.error('Failed to search Google Drive', { error: err });
+    logger.error('Failed to search Google Drive', { userId: req.user.id, query, error: err });
     res.status(500).json({ error: 'Failed to search drive' });
   }
 });

--- a/services/googleAuth.js
+++ b/services/googleAuth.js
@@ -18,7 +18,10 @@ class GoogleAuthService {
 
   generateAuthUrl(state) {
     const client = this.createOAuthClient();
-    const scopes = ['https://www.googleapis.com/auth/spreadsheets.readonly'];
+    const scopes = [
+      'https://www.googleapis.com/auth/spreadsheets.readonly',
+      'https://www.googleapis.com/auth/drive.readonly'
+    ];
     return client.generateAuthUrl({
       access_type: 'offline',
       scope: scopes,

--- a/services/googleAuth.js
+++ b/services/googleAuth.js
@@ -79,6 +79,11 @@ class GoogleAuthService {
 
     return client;
   }
+
+  async hasTokens(userId) {
+    const token = await GoogleToken.findOne({ userId });
+    return !!token;
+  }
 }
 
 module.exports = GoogleAuthService;

--- a/services/googleSheets.js
+++ b/services/googleSheets.js
@@ -1,5 +1,6 @@
 const { google } = require('googleapis');
 const GoogleAuthService = require('./googleAuth');
+const { logger } = require('./logging');
 
 class GoogleSheetsService {
   constructor() {
@@ -7,28 +8,33 @@ class GoogleSheetsService {
   }
 
   async getSheetData(userId, spreadsheetId, range = 'Sheet1', exclude = []) {
-    const auth = await this.authService.getOAuthClient(userId);
-    const sheets = google.sheets({ version: 'v4', auth });
+    try {
+      const auth = await this.authService.getOAuthClient(userId);
+      const sheets = google.sheets({ version: 'v4', auth });
 
-    const response = await sheets.spreadsheets.values.get({
-      spreadsheetId,
-      range
-    });
+      const response = await sheets.spreadsheets.values.get({
+        spreadsheetId,
+        range
+      });
 
-    const values = response.data.values || [];
-    if (values.length === 0) {
-      return {header: [], rows: []};
-    }
-    const [header, ...rows] = values;
-    const indices = header.reduce((acc, col, idx) => {
-      if (exclude.includes(col)) {
-        acc.push(idx);
+      const values = response.data.values || [];
+      if (values.length === 0) {
+        return { header: [], rows: [] };
       }
-      return acc;
-    }, []);
-    const filteredHeader = header.filter((_, idx) => !indices.includes(idx));
-    const filteredRows = rows.map(row => row.filter((_, idx) => !indices.includes(idx)));
-    return { header: filteredHeader, rows: filteredRows };
+      const [header, ...rows] = values;
+      const indices = header.reduce((acc, col, idx) => {
+        if (exclude.includes(col)) {
+          acc.push(idx);
+        }
+        return acc;
+      }, []);
+      const filteredHeader = header.filter((_, idx) => !indices.includes(idx));
+      const filteredRows = rows.map(row => row.filter((_, idx) => !indices.includes(idx)));
+      return { header: filteredHeader, rows: filteredRows };
+    } catch (error) {
+      logger.error('Error fetching spreadsheet data from Google', { error });
+      throw error;
+    }
   }
 }
 

--- a/services/knowledge.js
+++ b/services/knowledge.js
@@ -1,0 +1,54 @@
+const KnowledgeDocument = require('../models/knowledgeDocument');
+const GoogleSheetsService = require('./googleSheets');
+
+class KnowledgeService {
+  constructor() {
+    this.sheetsService = new GoogleSheetsService();
+  }
+
+  async importSpreadsheet(userId, spreadsheetId, exclude = []) {
+    const sheet = await this.sheetsService.getSheetData(userId, spreadsheetId, 'Sheet1');
+    const columns = sheet.header.map(name => ({ name, exclude: exclude.includes(name) }));
+    const doc = await KnowledgeDocument.findOneAndUpdate(
+      { userId, spreadsheetId },
+      { title: spreadsheetId, columns, rows: sheet.rows },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    return doc;
+  }
+
+  async list(userId, query = '') {
+    const q = query
+      ? { $or: [
+          { title: { $regex: query, $options: 'i' } },
+          { spreadsheetId: { $regex: query, $options: 'i' } }
+        ] }
+      : {};
+    return KnowledgeDocument.find({ userId, ...q }).select('spreadsheetId title createdAt');
+  }
+
+  async get(userId, id) {
+    return KnowledgeDocument.findOne({ _id: id, userId });
+  }
+
+  async refresh(userId, id) {
+    const doc = await KnowledgeDocument.findOne({ _id: id, userId });
+    if (!doc) throw new Error('Document not found');
+    const excludeMap = doc.columns.reduce((acc, c) => { acc[c.name] = c.exclude; return acc; }, {});
+    const sheet = await this.sheetsService.getSheetData(userId, doc.spreadsheetId, 'Sheet1');
+    doc.columns = sheet.header.map(name => ({ name, exclude: excludeMap[name] || false }));
+    doc.rows = sheet.rows;
+    await doc.save();
+    return doc;
+  }
+
+  async updateColumns(userId, id, excluded) {
+    const doc = await KnowledgeDocument.findOne({ _id: id, userId });
+    if (!doc) throw new Error('Document not found');
+    doc.columns.forEach(col => { col.exclude = excluded.includes(col.name); });
+    await doc.save();
+    return doc;
+  }
+}
+
+module.exports = KnowledgeService;

--- a/services/knowledge.js
+++ b/services/knowledge.js
@@ -1,5 +1,6 @@
 const KnowledgeDocument = require('../models/knowledgeDocument');
 const GoogleSheetsService = require('./googleSheets');
+const { logger } = require('./logging');
 
 class KnowledgeService {
   constructor() {
@@ -7,14 +8,19 @@ class KnowledgeService {
   }
 
   async importSpreadsheet(userId, spreadsheetId, exclude = []) {
-    const sheet = await this.sheetsService.getSheetData(userId, spreadsheetId, 'Sheet1');
-    const columns = sheet.header.map(name => ({ name, exclude: exclude.includes(name) }));
-    const doc = await KnowledgeDocument.findOneAndUpdate(
-      { userId, spreadsheetId },
-      { title: spreadsheetId, columns, rows: sheet.rows },
-      { new: true, upsert: true, setDefaultsOnInsert: true }
-    );
-    return doc;
+    try {
+      const sheet = await this.sheetsService.getSheetData(userId, spreadsheetId, 'Sheet1');
+      const columns = sheet.header.map(name => ({ name, exclude: exclude.includes(name) }));
+      const doc = await KnowledgeDocument.findOneAndUpdate(
+        { userId, spreadsheetId },
+        { title: spreadsheetId, columns, rows: sheet.rows },
+        { new: true, upsert: true, setDefaultsOnInsert: true }
+      );
+      return doc;
+    } catch (error) {
+      logger.error('Error importing spreadsheet', { error });
+      throw error;
+    }
   }
 
   async list(userId, query = '') {
@@ -32,22 +38,32 @@ class KnowledgeService {
   }
 
   async refresh(userId, id) {
-    const doc = await KnowledgeDocument.findOne({ _id: id, userId });
-    if (!doc) throw new Error('Document not found');
-    const excludeMap = doc.columns.reduce((acc, c) => { acc[c.name] = c.exclude; return acc; }, {});
-    const sheet = await this.sheetsService.getSheetData(userId, doc.spreadsheetId, 'Sheet1');
-    doc.columns = sheet.header.map(name => ({ name, exclude: excludeMap[name] || false }));
-    doc.rows = sheet.rows;
-    await doc.save();
-    return doc;
+    try {
+      const doc = await KnowledgeDocument.findOne({ _id: id, userId });
+      if (!doc) throw new Error('Document not found');
+      const excludeMap = doc.columns.reduce((acc, c) => { acc[c.name] = c.exclude; return acc; }, {});
+      const sheet = await this.sheetsService.getSheetData(userId, doc.spreadsheetId, 'Sheet1');
+      doc.columns = sheet.header.map(name => ({ name, exclude: excludeMap[name] || false }));
+      doc.rows = sheet.rows;
+      await doc.save();
+      return doc;
+    } catch (error) {
+      logger.error('Error refreshing spreadsheet', { error });
+      throw error;
+    }
   }
 
   async updateColumns(userId, id, excluded) {
-    const doc = await KnowledgeDocument.findOne({ _id: id, userId });
-    if (!doc) throw new Error('Document not found');
-    doc.columns.forEach(col => { col.exclude = excluded.includes(col.name); });
-    await doc.save();
-    return doc;
+    try {
+      const doc = await KnowledgeDocument.findOne({ _id: id, userId });
+      if (!doc) throw new Error('Document not found');
+      doc.columns.forEach(col => { col.exclude = excluded.includes(col.name); });
+      await doc.save();
+      return doc;
+    } catch (error) {
+      logger.error('Error updating excluded columns', { error });
+      throw error;
+    }
   }
 }
 

--- a/services/userGoogleDrive.js
+++ b/services/userGoogleDrive.js
@@ -9,8 +9,16 @@ class UserGoogleDrive {
   async searchSpreadsheets(userId, query = '') {
     const auth = await this.authService.getOAuthClient(userId);
     const drive = google.drive({ version: 'v3', auth });
+
+    const parts = ["mimeType='application/vnd.google-apps.spreadsheet'", 'trashed=false'];
+    if (query) {
+      const escaped = query.replace(/'/g, "\\'");
+      parts.push(`name contains '${escaped}'`);
+    }
+    const q = parts.join(' and ');
+
     const res = await drive.files.list({
-      q: `mimeType='application/vnd.google-apps.spreadsheet' and name contains '${query}'`,
+      q,
       fields: 'files(id,name)',
       spaces: 'drive'
     });

--- a/services/userGoogleDrive.js
+++ b/services/userGoogleDrive.js
@@ -7,28 +7,59 @@ class UserGoogleDrive {
     this.authService = new GoogleAuthService();
   }
 
+  /**
+   * Searches for non-trashed Google Spreadsheets in a user's Drive,
+   * fetching all pages of results.
+   * @param {string} userId - The ID of the user to authenticate as.
+   * @param {string} [query=''] - An optional string to filter files by name.
+   * @returns {Promise<Array<Object>>} A promise that resolves to an array of file objects.
+   * @throws Will throw an error if the API call fails.
+   */
   async searchSpreadsheets(userId, query = '') {
     try {
       const auth = await this.authService.getOAuthClient(userId);
       const drive = google.drive({ version: 'v3', auth });
 
-      const parts = ["mimeType='application/vnd.google-apps.spreadsheet'", 'trashed=false'];
+      const queryParts = ["mimeType='application/vnd.google-apps.spreadsheet'", 'trashed=false'];
+
       if (query) {
-        const escaped = query.replace(/'/g, "\\'");
-        parts.push(`name contains '${escaped}'`);
+        // DEFECT FIX #3: More robustly escape backslashes and single quotes.
+        const escapedQuery = query.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+        queryParts.push(`name contains '${escapedQuery}'`);
       }
-      const q = parts.join(' and ');
+      const q = queryParts.join(' and ');
 
       logger.debug('Searching Google Drive', { userId, query, q });
-      const res = await drive.files.list({
-        q,
-        fields: 'files(id,name)',
-        spaces: 'drive'
-      });
-      logger.debug('Google Drive search complete', { userId, count: res.data.files?.length || 0 });
-      return res.data.files || [];
+
+      // DEFECT FIX #2: Implement pagination to fetch all results.
+      let allFiles = [];
+      let pageToken = null;
+      do {
+        const res = await drive.files.list({
+          q,
+          fields: 'files(id,name),nextPageToken',
+          spaces: 'drive',
+          pageSize: 1000,
+          pageToken: pageToken
+        });
+
+        if (res.data.files) {
+          allFiles = allFiles.concat(res.data.files);
+        }
+        pageToken = res.data.nextPageToken; // Get the token for the next iteration
+      } while (pageToken);
+
+      logger.debug('Google Drive search complete', { userId, count: allFiles.length });
+      return allFiles;
+
     } catch (error) {
-      logger.error('Error searching Google Drive', { userId, query, error });
+      const apiError = error.response ? error.response.data : error.message;
+      logger.error(`Error searching Google Drive: ${JSON.stringify({
+        userId,
+        query,
+        error: apiError
+      })}`);
+
       throw error;
     }
   }

--- a/services/userGoogleDrive.js
+++ b/services/userGoogleDrive.js
@@ -1,0 +1,21 @@
+const { google } = require('googleapis');
+const GoogleAuthService = require('./googleAuth');
+
+class UserGoogleDrive {
+  constructor() {
+    this.authService = new GoogleAuthService();
+  }
+
+  async searchSpreadsheets(userId, query = '') {
+    const auth = await this.authService.getOAuthClient(userId);
+    const drive = google.drive({ version: 'v3', auth });
+    const res = await drive.files.list({
+      q: `mimeType='application/vnd.google-apps.spreadsheet' and name contains '${query}'`,
+      fields: 'files(id,name)',
+      spaces: 'drive'
+    });
+    return res.data.files || [];
+  }
+}
+
+module.exports = UserGoogleDrive;

--- a/services/userGoogleDrive.js
+++ b/services/userGoogleDrive.js
@@ -19,14 +19,16 @@ class UserGoogleDrive {
       }
       const q = parts.join(' and ');
 
+      logger.debug('Searching Google Drive', { userId, query, q });
       const res = await drive.files.list({
         q,
         fields: 'files(id,name)',
         spaces: 'drive'
       });
+      logger.debug('Google Drive search complete', { userId, count: res.data.files?.length || 0 });
       return res.data.files || [];
     } catch (error) {
-      logger.error('Error searching Google Drive', { error });
+      logger.error('Error searching Google Drive', { userId, query, error });
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- organize admin settings sections
- add PDF generation toggle
- rename Google Knowledge section
- remove Save Settings button
- expand knowledge management via Google Drive
- show connection status and add search of stored spreadsheets
- store entire spreadsheets and track excluded columns separately
- gray out excluded columns in knowledge preview

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851dabdae88833094c86e1573ca1a3c